### PR TITLE
Modernize Batch sample so pool deploys on current Azure

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -22,13 +22,13 @@ namespace Microsoft.Azure.Batch.Samples.DotNetTutorial
         // These are used when constructing connection strings for the Batch and Storage client objects.
 
         // Batch account credentials
-        private const string BatchAccountName = "waltsbatchtestvnet";
-        private const string BatchAccountKey  = "8Y/932u5JMch/8mxGBU4MnmX0YoFdCbevNHREQlllSsmqCKerqHgQrfqqfO6FXJvD+lfsk0XK4hSJupYLzLTkQ==";
-        private const string BatchAccountUrl  = "https://waltsbatchtestvnet.westus2.batch.azure.com";
+        private const string BatchAccountName = "";
+        private const string BatchAccountKey  = "";
+        private const string BatchAccountUrl  = "";
 
         // Storage account credentials
-        private const string StorageAccountName = "batchstoragetester";
-        private const string StorageAccountKey  = "yyCjwGoM4KmeLa5XfN+PpPOnx/es8ZAlknyCwgGg7PfVmTyQyRYu7vtM3cCRNztag/IJ2WCn7gk/7VqMxbTm4A==";
+        private const string StorageAccountName = "";
+        private const string StorageAccountKey  = "";
         
         private const string PoolId = "batch_assessment_04_pool";
         private const string JobId  = "batch_assessment_04_job";

--- a/README.md
+++ b/README.md
@@ -4,15 +4,31 @@
 This is a Level 200 lab for the Troubleshooting in Azure Batch.
 ## Deployment Instructions
 
+Deploy the ARM template **`azuredeploy.json`** (in the root of this repo) using **either** option below.
+
+### Option 1 - Azure CLI (recommended)
+```powershell
+az group create -n rg-batch-lab-04 -l westus2
+az deployment group create -g rg-batch-lab-04 --template-file azuredeploy.json --parameters namePrefix=batlab04
+az deployment group show -g rg-batch-lab-04 -n azuredeploy --query properties.outputs
+```
+
+### Option 2 - Azure Portal (Load file)
+1. Portal -> search **Deploy a custom template** -> **Build your own template in the editor**.
+2. **Load file** -> select `azuredeploy.json` from this repo -> **Save**.
+3. Choose/create a resource group + region, set `namePrefix`, then **Review + create** -> **Create**.
+
+### Option 3 - Deploy to Azure button
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fcdn.jsdelivr.net%2Fgh%2FWalter-B-Jr%2FAzure_Batch_Assessment_04%40master%2Fazuredeploy.json)
 
-Click **Deploy to Azure** above, choose (or create) a resource group and region, then **Review + create**. When the deployment completes, open its **Outputs** to get `batchAccountName`, `batchAccountUrl`, and `storageAccountName`.
+> Note: the one-click button fetches the template from a public CDN. Some corporate networks block that outbound fetch (the portal then shows a generic "enable CORS" error) - use Option 1 or 2 instead.
 
-Get the account keys from the portal:
-- Batch account -> **Keys** -> copy the account **URL** and **Primary access key**.
-- Storage account -> **Access keys** -> copy the account name and **key1**.
+### After deploying
+Open the deployment **Outputs** for `batchAccountName`, `batchAccountUrl`, and `storageAccountName`, then get the keys from the portal:
+- Batch account -> **Keys** -> account **URL** + **Primary access key**.
+- Storage account -> **Access keys** -> account name + **key1**.
 
-Paste those values into `DotNetTutorial\Program.cs` (`BatchAccountName`, `BatchAccountUrl`, `BatchAccountKey`, `StorageAccountName`, `StorageAccountKey`), then build and run the console app.
+Paste these into `DotNetTutorial\Program.cs` (`BatchAccountName`, `BatchAccountUrl`, `BatchAccountKey`, `StorageAccountName`, `StorageAccountKey`), then build and run the console app.
 
 <details><summary>Manual deployment (alternative)</summary>
 1.	Deploy the template and download the source code. https://github.com/Walter-B-Jr/Azure_Batch_Assessment_04

--- a/README.md
+++ b/README.md
@@ -4,24 +4,24 @@
 This is a Level 200 lab for the Troubleshooting in Azure Batch.
 ## Deployment Instructions
 
-Deploy the ARM template **`azuredeploy.json`** (in the root of this repo) using **either** option below.
+Deploy the ARM template **`azuredeploy.json`** (in the root of this repo) using any option below.
 
-### Option 1 - Azure CLI (recommended)
+### Option 1 - Deploy to Azure (one-click)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FWalter-B-Jr%2FAzure_Batch_Assessment_04%2Fmaster%2Fazuredeploy.json)
+
+Click the button, pick (or create) a resource group + region, set `namePrefix`, then **Review + create** -> **Create**.
+
+### Option 2 - Azure CLI
 ```powershell
 az group create -n rg-batch-lab-04 -l westus2
 az deployment group create -g rg-batch-lab-04 --template-file azuredeploy.json --parameters namePrefix=batlab04
 az deployment group show -g rg-batch-lab-04 -n azuredeploy --query properties.outputs
 ```
 
-### Option 2 - Azure Portal (Load file)
+### Option 3 - Azure Portal (Load file)
 1. Portal -> search **Deploy a custom template** -> **Build your own template in the editor**.
 2. **Load file** -> select `azuredeploy.json` from this repo -> **Save**.
 3. Choose/create a resource group + region, set `namePrefix`, then **Review + create** -> **Create**.
-
-### Option 3 - Deploy to Azure button
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fcdn.jsdelivr.net%2Fgh%2FWalter-B-Jr%2FAzure_Batch_Assessment_04%40master%2Fazuredeploy.json)
-
-> Note: the one-click button fetches the template from a public CDN. Some corporate networks block that outbound fetch (the portal then shows a generic "enable CORS" error) - use Option 1 or 2 instead.
 
 ### After deploying
 Open the deployment **Outputs** for `batchAccountName`, `batchAccountUrl`, and `storageAccountName`, then get the keys from the portal:

--- a/README.md
+++ b/README.md
@@ -3,9 +3,21 @@
 ## Introduction
 This is a Level 200 lab for the Troubleshooting in Azure Batch.
 ## Deployment Instructions
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FWalter-B-Jr%2FAzure_Batch_Assessment_04%2Fmaster%2Fazuredeploy.json)
+
+Click **Deploy to Azure** above, choose (or create) a resource group and region, then **Review + create**. When the deployment completes, open its **Outputs** to get `batchAccountName`, `batchAccountUrl`, and `storageAccountName`.
+
+Get the account keys from the portal:
+- Batch account -> **Keys** -> copy the account **URL** and **Primary access key**.
+- Storage account -> **Access keys** -> copy the account name and **key1**.
+
+Paste those values into `DotNetTutorial\Program.cs` (`BatchAccountName`, `BatchAccountUrl`, `BatchAccountKey`, `StorageAccountName`, `StorageAccountKey`), then build and run the console app.
+
+<details><summary>Manual deployment (alternative)</summary>
 1.	Deploy the template and download the source code. https://github.com/Walter-B-Jr/Azure_Batch_Assessment_04
 2.	Open up the application that was created in the deployment template to get the credentials required for the sample code to work correctly. Then, proceed to open the code sample in VS and make the following required changes:
-a.	Open “Program.cs” under DotNetTutorial application. 
+a.	Open ï¿½Program.csï¿½ under DotNetTutorial application. 
 b.	Proceed to enter the credentials provided in the application to the code sample as shown below
 i.	BatchAccountName
 ii.	BatchAccountKey
@@ -14,20 +26,22 @@ iv.	StorageAccountName
 v.	StorageAccountKey
 vi.	You can name your PoolID and JobID however you desire.
 
+</details>
+
 ## Resources Created
 This lab involves the following resources.
 -	Resource Group
 -	Batch Account 
 -	Storage Account 
--	Application – (which contains Batch and Storage credentials
+-	Application ï¿½ (which contains Batch and Storage credentials
 ## Scenario
-1.	After running the job, the job is supposed to take only ~5 minutes to run after being scheduled, according to the customer (Note: this is specifically for this scenario. A Job will take however long it is necessary to run the customers Tasks code or reach the timeout specified by customer…). After running, the Job is still in Active State. The customer has set the Job to terminate after completion. 
+1.	After running the job, the job is supposed to take only ~5 minutes to run after being scheduled, according to the customer (Note: this is specifically for this scenario. A Job will take however long it is necessary to run the customers Tasks code or reach the timeout specified by customerï¿½). After running, the Job is still in Active State. The customer has set the Job to terminate after completion. 
 2.	You are required to identify why the Job failed to terminate. Remember, the customer has configured the Job to terminate after completion.
 3.	The engineer should take a screenshot of how they identified the error (using Kusto and Azure Batch Diagnostics) and explain the reason why the Job failed to complete/terminate.
  
 ## Your Goal
-Your goal is to identify why the Job is remaining in “active” state (Kusto & Azure Batch diagnostics). Take a snapshot of the two tools (Kusto & Azure Batch diagnostics) once you find the indication of error. Also, explain why the Job never terminates. 
+Your goal is to identify why the Job is remaining in ï¿½activeï¿½ state (Kusto & Azure Batch diagnostics). Take a snapshot of the two tools (Kusto & Azure Batch diagnostics) once you find the indication of error. Also, explain why the Job never terminates. 
 ## Proof of Solution
-1.	Provide a screen capture of KUSTO once you have found the error, highlighting the relevant indicators of why the Job might still be in an “Active” state.
-2.	Provide a screen capture of the AzureBatchDiagnostics once you have found the error. Again, highlight the relevant indicators of why the Job might still be in an “Active” state.
-3.	Bonus: Explain why the Job failed to terminate and is still in “Active” state after 5 minutes (when the Job should have completed).
+1.	Provide a screen capture of KUSTO once you have found the error, highlighting the relevant indicators of why the Job might still be in an ï¿½Activeï¿½ state.
+2.	Provide a screen capture of the AzureBatchDiagnostics once you have found the error. Again, highlight the relevant indicators of why the Job might still be in an ï¿½Activeï¿½ state.
+3.	Bonus: Explain why the Job failed to terminate and is still in ï¿½Activeï¿½ state after 5 minutes (when the Job should have completed).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This is a Level 200 lab for the Troubleshooting in Azure Batch.
 ## Deployment Instructions
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FWalter-B-Jr%2FAzure_Batch_Assessment_04%2Fmaster%2Fazuredeploy.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fcdn.jsdelivr.net%2Fgh%2FWalter-B-Jr%2FAzure_Batch_Assessment_04%40master%2Fazuredeploy.json)
 
 Click **Deploy to Azure** above, choose (or create) a resource group and region, then **Review + create**. When the deployment completes, open its **Outputs** to get `batchAccountName`, `batchAccountUrl`, and `storageAccountName`.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ This lab involves the following resources.
 -	Resource Group
 -	Batch Account 
 -	Storage Account 
--	Application � (which contains Batch and Storage credentials
 ## Scenario
 1.	After running the job, the job is supposed to take only ~5 minutes to run after being scheduled, according to the customer (Note: this is specifically for this scenario. A Job will take however long it is necessary to run the customers Tasks code or reach the timeout specified by customer�). After running, the Job is still in Active State. The customer has set the Job to terminate after completion. 
 2.	You are required to identify why the Job failed to terminate. Remember, the customer has configured the Job to terminate after completion.

--- a/azuredeploy.bicep
+++ b/azuredeploy.bicep
@@ -1,0 +1,44 @@
+// Standard Batch + Storage environment for the code-failure labs (_01, _03, _04).
+// These labs' intentional failures live in the SAMPLE CODE, not in infrastructure,
+// so this template deploys a plain, fully public Batch account + Storage account.
+// Author/grader use only. Do NOT commit to the engineer-facing repos.
+
+@description('Prefix for generated resource names.')
+param namePrefix string = 'batlab'
+
+@description('Azure region for all resources.')
+param location string = resourceGroup().location
+
+var suffix = uniqueString(resourceGroup().id)
+var storageAccountName = toLower('${namePrefix}${suffix}')
+var batchAccountName = toLower('${namePrefix}ba${suffix}')
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: length(storageAccountName) > 24 ? substring(storageAccountName, 0, 24) : storageAccountName
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    allowBlobPublicAccess: false
+  }
+}
+
+resource batch 'Microsoft.Batch/batchAccounts@2024-07-01' = {
+  name: length(batchAccountName) > 24 ? substring(batchAccountName, 0, 24) : batchAccountName
+  location: location
+  properties: {
+    autoStorage: {
+      storageAccountId: storage.id
+    }
+    poolAllocationMode: 'BatchService'
+    // Fully public data-plane and node-management: nothing here causes a failure.
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+output batchAccountName string = batch.name
+output batchAccountUrl string = 'https://${batch.properties.accountEndpoint}'
+output storageAccountName string = storage.name

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.45.15.27210",
+      "templateHash": "11246634116886271593"
+    }
+  },
+  "parameters": {
+    "namePrefix": {
+      "type": "string",
+      "defaultValue": "batlab",
+      "metadata": {
+        "description": "Prefix for generated resource names."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Azure region for all resources."
+      }
+    }
+  },
+  "variables": {
+    "suffix": "[uniqueString(resourceGroup().id)]",
+    "storageAccountName": "[toLower(format('{0}{1}', parameters('namePrefix'), variables('suffix')))]",
+    "batchAccountName": "[toLower(format('{0}ba{1}', parameters('namePrefix'), variables('suffix')))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-05-01",
+      "name": "[if(greater(length(variables('storageAccountName')), 24), substring(variables('storageAccountName'), 0, 24), variables('storageAccountName'))]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "minimumTlsVersion": "TLS1_2",
+        "allowBlobPublicAccess": false
+      }
+    },
+    {
+      "type": "Microsoft.Batch/batchAccounts",
+      "apiVersion": "2024-07-01",
+      "name": "[if(greater(length(variables('batchAccountName')), 24), substring(variables('batchAccountName'), 0, 24), variables('batchAccountName'))]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "autoStorage": {
+          "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', if(greater(length(variables('storageAccountName')), 24), substring(variables('storageAccountName'), 0, 24), variables('storageAccountName')))]"
+        },
+        "poolAllocationMode": "BatchService",
+        "publicNetworkAccess": "Enabled"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', if(greater(length(variables('storageAccountName')), 24), substring(variables('storageAccountName'), 0, 24), variables('storageAccountName')))]"
+      ]
+    }
+  ],
+  "outputs": {
+    "batchAccountName": {
+      "type": "string",
+      "value": "[if(greater(length(variables('batchAccountName')), 24), substring(variables('batchAccountName'), 0, 24), variables('batchAccountName'))]"
+    },
+    "batchAccountUrl": {
+      "type": "string",
+      "value": "[format('https://{0}', reference(resourceId('Microsoft.Batch/batchAccounts', if(greater(length(variables('batchAccountName')), 24), substring(variables('batchAccountName'), 0, 24), variables('batchAccountName'))), '2024-07-01').accountEndpoint)]"
+    },
+    "storageAccountName": {
+      "type": "string",
+      "value": "[if(greater(length(variables('storageAccountName')), 24), substring(variables('storageAccountName'), 0, 24), variables('storageAccountName'))]"
+    }
+  }
+}


### PR DESCRIPTION
Removes hard-coded Batch/Storage account keys from `Program.cs` (supplied per deployment).
---

**One-click deploy:** Adds `azuredeploy.json` (ARM) and a **Deploy to Azure** button in the README so the lab environment deploys in one click. Open the deployment's **Outputs**, copy the account keys from the portal, paste into `DotNetTutorial\Program.cs`, then run the sample.

> Note: the Deploy button reads `azuredeploy.json` from the `master` branch, so it becomes live once this PR is merged.